### PR TITLE
Simplify networking by using host IP alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,9 @@ sudo systemctl stop samba-ad-ip.service
 If the container fails to start due to port conflicts, ensure no other Samba
 services are running on the host. The `create-network.sh` script stops them
 automatically, but they may have restarted after a reboot.
+
+The script checks that required ports on the dedicated IP are free. If you see
+an error that port `53` is in use, it is often due to `systemd-resolved` binding
+DNS on `127.0.0.53`. Because this only listens on the loopback interface it will
+not conflict with the container. You can safely ignore the warning or disable
+`systemd-resolved` if necessary.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# Samba Active Directory Container
+
+This repository contains a Docker setup for running Samba as an Active Directory Domain Controller.
+
+## Prerequisites
+
+- Docker Engine and Docker Compose
+- A network interface on the host that will own the dedicated IP address
+- Systemd (used to persist the IP alias)
+
+## Configuration
+
+1. Copy `.env` and adjust the values for your environment. At a minimum set:
+   - `SAMBA_IPV4_ADDRESS` - the dedicated IP for the container
+   - `SAMBA_PARENT_INTERFACE` - the host interface to bind the alias
+   - `SAMBA_DOMAIN`, `SAMBA_REALM`, `SAMBA_ADMIN_PASSWORD`, etc.
+
+2. Run the network helper script to configure the host IP alias (requires sudo):
+
+```bash
+sudo ./create-network.sh
+```
+
+This script stops any running host Samba services (`smbd`, `nmbd`, `winbindd`) and
+adds the IP alias. A systemd service named `samba-ad-ip.service` is created to
+reapply the alias on boot.
+
+## Deployment
+
+Start the container using Docker Compose:
+
+```bash
+docker compose up -d
+```
+
+The Samba AD DC will be accessible at the IP specified in `.env`.
+
+To remove the setup, stop the stack and delete the alias:
+
+```bash
+docker compose down
+sudo systemctl stop samba-ad-ip.service
+```
+
+## Troubleshooting
+
+If the container fails to start due to port conflicts, ensure no other Samba
+services are running on the host. The `create-network.sh` script stops them
+automatically, but they may have restarted after a reboot.

--- a/create-network.sh
+++ b/create-network.sh
@@ -58,10 +58,19 @@ if [ -z "$GATEWAY" ]; then
 fi
 
 # Check if the IP is already in use
+
 if ping -c 1 -W 1 "$CONTAINER_IP" >/dev/null 2>&1; then
         echo "❌ Error: IP $CONTAINER_IP is already in use"
         exit 1
 fi
+
+# Stop any host Samba services that might occupy the required ports
+for svc in smbd nmbd winbindd; do
+        if systemctl is-active --quiet "$svc"; then
+                echo "Stopping $svc to free ports..."
+                systemctl stop "$svc"
+        fi
+done
 
 # Check if required ports are free before configuring the IP alias
 check_port() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,23 @@ services:
       - samba_logs:/var/log/samba
       - samba_sysvol:/var/lib/samba/sysvol
       - samba_netlogon:/var/lib/samba/netlogon
-    networks:
-      samba_macvlan:
-        ipv4_address: ${SAMBA_IPV4_ADDRESS}
+    ports:
+      - "${SAMBA_IPV4_ADDRESS}:53:53/tcp"
+      - "${SAMBA_IPV4_ADDRESS}:53:53/udp"
+      - "${SAMBA_IPV4_ADDRESS}:88:88/tcp"
+      - "${SAMBA_IPV4_ADDRESS}:88:88/udp"
+      - "${SAMBA_IPV4_ADDRESS}:135:135/tcp"
+      - "${SAMBA_IPV4_ADDRESS}:137:137/udp"
+      - "${SAMBA_IPV4_ADDRESS}:138:138/udp"
+      - "${SAMBA_IPV4_ADDRESS}:139:139/tcp"
+      - "${SAMBA_IPV4_ADDRESS}:389:389/tcp"
+      - "${SAMBA_IPV4_ADDRESS}:389:389/udp"
+      - "${SAMBA_IPV4_ADDRESS}:445:445/tcp"
+      - "${SAMBA_IPV4_ADDRESS}:464:464/tcp"
+      - "${SAMBA_IPV4_ADDRESS}:464:464/udp"
+      - "${SAMBA_IPV4_ADDRESS}:636:636/tcp"
+      - "${SAMBA_IPV4_ADDRESS}:3268:3268/tcp"
+      - "${SAMBA_IPV4_ADDRESS}:3269:3269/tcp"
     dns:
       - 127.0.0.1
 
@@ -34,6 +48,3 @@ volumes:
   samba_sysvol:
   samba_netlogon:
 
-networks:
-  samba_macvlan:
-    external: true


### PR DESCRIPTION
## Summary
- configure the host with a persistent IP alias via systemd
- expose Samba ports on the alias instead of macvlan

## Testing
- `shellcheck create-network.sh`
- `bash -n create-network.sh`


------
https://chatgpt.com/codex/tasks/task_e_687687fed0dc832384ffccab288ca043